### PR TITLE
Update repository to be 4.5 instead of 4.5milestones

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
 		</repository>
 		<repository>
 			<id>platform</id>
-			<url>http://download.eclipse.org/eclipse/updates/4.5milestones/</url>
+			<url>http://download.eclipse.org/eclipse/updates/4.5/</url>
 			<layout>p2</layout>
 		</repository>
 		<repository>


### PR DESCRIPTION
This pull request is for the repo being out of date.

Torkild, thanks for adding the preference for the target chooser, it is a great addition and saves valuable screen space for my typical flow. I find that I almost always use the launch bar now.
